### PR TITLE
feat: User score + avatar (fixes #16)

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,14 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :trackable
   has_many :posts, dependent: :destroy
+  has_one_attached :avatar
   validates :slug, uniqueness: true
+  validate :avatar_must_be_image, if: -> { avatar.attached? && avatar.changed? }
+
+  IMAGE_CONTENT_TYPES = %w[image/jpeg image/png image/gif image/webp].freeze
   before_validation :set_slug, if: -> { slug.nil? }
+
+  scope :top_10_by_score, -> { order(score: :desc).limit(10) }
 
   has_many :invitations
   has_many :pending_invitations, -> { where confirmed: false }, class_name: 'Invitation', foreign_key: "friend_id"
@@ -65,6 +71,13 @@ class User < ApplicationRecord
       self.slug = full_name.parameterize + SecureRandom.hex(6)
     else
       self.slug = full_name.parameterize
+    end
+  end
+
+  def avatar_must_be_image
+    unless IMAGE_CONTENT_TYPES.include?(avatar.blob.content_type)
+      errors.add(:avatar, "must be an image (JPEG, PNG, GIF, or WebP)")
+      avatar.purge
     end
   end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -5,7 +5,7 @@
   </div>
 
   <div class="ck-card">
-    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, multipart: true }) do |f| %>
       <%= render "devise/shared/error_messages", resource: resource %>
 
       <div class="space-y-4">
@@ -35,10 +35,12 @@
 
         <div>
           <%= f.label :avatar, class: "ck-meta block mb-1" %>
-          <%= f.select :avatar,
-               [["Cooool Cactus", "cool-cactus.png"], ["DOGE", "cool-doge.png"], ["Funky Duck", "cool-duck.png"], ["Coolest duck", "coolest-duck.jpg"]],
-               { include_blank: false },
-               class: "ck-input" %>
+          <% if resource.avatar.attached? %>
+            <div class="mb-2">
+              <%= image_tag resource.avatar, class: "w-16 h-16 object-cover rounded-full" %>
+            </div>
+          <% end %>
+          <%= f.file_field :avatar, accept: "image/*", class: "ck-input" %>
         </div>
 
         <div style="border-top: 1px solid var(--ck-line); padding-top: 16px; margin-top: 8px;">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,7 @@
   <div class="flex items-start justify-between mb-8">
     <div class="flex items-center gap-4">
       <div class="w-16 h-16 rounded-full flex items-center justify-center text-[20px] font-semibold shrink-0" style="background: var(--ck-raised); color: var(--ck-ink);">
-        <% if @user.avatar&.present? %>
+        <% if @user.avatar.attached? %>
           <%= image_tag @user.avatar, class: "w-16 h-16 object-cover rounded-full" %>
         <% else %>
           <%= @user.initials %>
@@ -22,10 +22,14 @@
     <% end %>
   </div>
 
-  <div class="ck-stat-grid grid-cols-1 mb-8">
+  <div class="ck-stat-grid grid-cols-2 mb-8">
     <div>
       <div class="ck-meta mb-1">Challenges Solved</div>
       <div class="text-[22px] font-light tabular-nums" style="color: #a6d6ff;"><%= @user.challenge_completions.count %></div>
+    </div>
+    <div>
+      <div class="ck-meta mb-1">Score</div>
+      <div class="text-[22px] font-light tabular-nums" style="color: #a6d6ff;"><%= @user.score %></div>
     </div>
   </div>
 

--- a/db/migrate/20260430182123_add_score_to_users_and_drop_avatar_string.rb
+++ b/db/migrate/20260430182123_add_score_to_users_and_drop_avatar_string.rb
@@ -1,0 +1,6 @@
+class AddScoreToUsersAndDropAvatarString < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :users, :avatar, :string
+    add_column :users, :score, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_25_145720) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_30_182123) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -106,6 +106,23 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_25_145720) do
     t.index ["user_id"], name: "index_discussions_on_user_id"
   end
 
+  create_table "duels", force: :cascade do |t|
+    t.bigint "challenger_id"
+    t.bigint "opponent_id"
+    t.bigint "challenge_id"
+    t.bigint "winner_id"
+    t.integer "status", default: 0
+    t.datetime "started_at"
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["challenge_id"], name: "index_duels_on_challenge_id"
+    t.index ["challenger_id", "opponent_id", "status"], name: "index_duels_on_challenger_id_and_opponent_id_and_status"
+    t.index ["challenger_id"], name: "index_duels_on_challenger_id"
+    t.index ["opponent_id"], name: "index_duels_on_opponent_id"
+    t.index ["winner_id"], name: "index_duels_on_winner_id"
+  end
+
   create_table "invitations", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.integer "friend_id"
@@ -146,12 +163,12 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_25_145720) do
     t.string "first_name"
     t.string "last_name"
     t.string "slug"
-    t.string "avatar"
     t.integer "sign_in_count"
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
+    t.integer "score", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
@@ -177,6 +194,10 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_25_145720) do
   add_foreign_key "challenge_completions", "challenges"
   add_foreign_key "challenge_completions", "users"
   add_foreign_key "discussions", "users"
+  add_foreign_key "duels", "challenges"
+  add_foreign_key "duels", "users", column: "challenger_id"
+  add_foreign_key "duels", "users", column: "opponent_id"
+  add_foreign_key "duels", "users", column: "winner_id"
   add_foreign_key "invitations", "users"
   add_foreign_key "notifications", "users"
   add_foreign_key "posts", "discussions"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,7 +1,29 @@
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "score defaults to 0" do
+    user = User.create!(
+      email: "new@example.com",
+      password: "password",
+      first_name: "New",
+      last_name: "User"
+    )
+    assert_equal 0, user.score
+  end
+
+  test "top_10_by_score returns at most 10 users ordered by score descending" do
+    11.times do |i|
+      User.create!(
+        email: "scoretest#{i}@example.com",
+        password: "password",
+        first_name: "Score",
+        last_name: "User#{i}",
+        score: (i + 1) * 10
+      )
+    end
+    result = User.top_10_by_score
+    assert result.size <= 10
+    scores = result.map(&:score)
+    assert_equal scores, scores.sort.reverse
+  end
 end


### PR DESCRIPTION
## Summary

- Adds `score integer default 0 not null` column to `users` table
- Adds `User.top_10_by_score` scope (`order(score: :desc).limit(10)`)
- Replaces the old string `avatar` column with `has_one_attached :avatar` (Active Storage)
- Wires file upload on the settings page with image MIME type validation (JPEG, PNG, GIF, WebP)
- Displays uploaded avatar on the profile page; falls back to initials when no avatar is attached

## Test plan

- [x] `users.score` column exists with default 0 and NOT NULL — verified via migration
- [x] `User.top_10_by_score` returns ≤10 users in descending score order — unit test added
- [x] Upload an image on the settings page — avatar appears on the profile page
- [x] Profile shows initials when no avatar is uploaded
- [x] Uploading a non-image file is rejected with a validation error

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)