### PR TITLE
feat: Game + GameRound models + GameScorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@
 !/app/assets/builds/.keep
 
 /node_modules
+.worktrees/

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,0 +1,44 @@
+class Game < ApplicationRecord
+  belongs_to :challenger, class_name: "User"
+  belongs_to :opponent,   class_name: "User"
+  belongs_to :winner,     class_name: "User", optional: true
+
+  has_many :game_rounds, dependent: :destroy
+
+  enum :status,      { pending: 0, active: 1, completed: 2 }
+  enum :round_count, { one: 0, three: 1, five: 2 }
+  enum :difficulty,  { easy: 0, medium: 1, hard: 2 }
+
+  ROUNDS_TO_WIN = { "one" => 1, "three" => 2, "five" => 3 }.freeze
+
+  def winner_of_game
+    wins = game_rounds.where.not(round_winner_id: nil).group(:round_winner_id).count
+    target = ROUNDS_TO_WIN[round_count]
+
+    winner_id, count = wins.max_by { |_, c| c }
+    return nil if count.nil? || count < target
+
+    [ challenger, opponent ].find { |u| u.id == winner_id }
+  end
+
+  def apply_scores!
+    game_winner = winner_of_game
+    return unless game_winner
+
+    loser = game_winner == challenger ? opponent : challenger
+    completed = game_rounds.where.not(round_winner_id: nil)
+
+    winner_rounds = completed.where(round_winner_id: game_winner.id).count
+    loser_rounds  = completed.where(round_winner_id: loser.id).count
+
+    winner_delta = GameScorer.score_for_winner(
+      rounds_won: winner_rounds, rounds_lost: loser_rounds, opponent_score: loser.score
+    )
+    loser_delta = GameScorer.score_for_loser(rounds_won: loser_rounds)
+
+    Game.transaction do
+      game_winner.increment!(:score, winner_delta)
+      loser.increment!(:score, loser_delta) if loser_delta > 0
+    end
+  end
+end

--- a/app/models/game_round.rb
+++ b/app/models/game_round.rb
@@ -1,0 +1,26 @@
+class GameRound < ApplicationRecord
+  belongs_to :game
+  belongs_to :challenge
+  belongs_to :round_winner, class_name: "User", optional: true
+
+  scope :ordered, -> { order(:round_number) }
+
+  def complete!(winner:)
+    update!(round_winner: winner, completed_at: Time.current)
+    trigger_game_completion
+  end
+
+  private
+
+  def trigger_game_completion
+    potential_winner = game.winner_of_game
+    return unless potential_winner
+
+    game.update!(
+      winner: potential_winner,
+      status: :completed,
+      completed_at: Time.current
+    )
+    game.apply_scores!
+  end
+end

--- a/app/services/game_scorer.rb
+++ b/app/services/game_scorer.rb
@@ -1,0 +1,9 @@
+class GameScorer
+  def self.score_for_winner(rounds_won:, rounds_lost:, opponent_score:)
+    rounds_won + 3 + [opponent_score / 20, 50].min - rounds_lost
+  end
+
+  def self.score_for_loser(rounds_won:)
+    [rounds_won, 0].max
+  end
+end

--- a/db/migrate/20260430191227_create_games.rb
+++ b/db/migrate/20260430191227_create_games.rb
@@ -1,0 +1,15 @@
+class CreateGames < ActiveRecord::Migration[7.1]
+  def change
+    create_table :games do |t|
+      t.references :challenger, null: false, foreign_key: { to_table: :users }
+      t.references :opponent,   null: false, foreign_key: { to_table: :users }
+      t.references :winner,     null: true,  foreign_key: { to_table: :users }
+      t.integer :status,      null: false, default: 0
+      t.integer :round_count, null: false
+      t.integer :difficulty,  null: false
+      t.datetime :started_at
+      t.datetime :completed_at
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260430191251_create_game_rounds.rb
+++ b/db/migrate/20260430191251_create_game_rounds.rb
@@ -1,0 +1,14 @@
+class CreateGameRounds < ActiveRecord::Migration[7.1]
+  def change
+    create_table :game_rounds do |t|
+      t.references :game,         null: false, foreign_key: true
+      t.references :challenge,    null: false, foreign_key: true
+      t.references :round_winner, null: true,  foreign_key: { to_table: :users }
+      t.text    :challenger_code
+      t.text    :opponent_code
+      t.integer :round_number, null: false
+      t.datetime :completed_at
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_30_182123) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_30_191251) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -123,6 +123,37 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_30_182123) do
     t.index ["winner_id"], name: "index_duels_on_winner_id"
   end
 
+  create_table "game_rounds", force: :cascade do |t|
+    t.bigint "game_id", null: false
+    t.bigint "challenge_id", null: false
+    t.bigint "round_winner_id"
+    t.text "challenger_code"
+    t.text "opponent_code"
+    t.integer "round_number", null: false
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["challenge_id"], name: "index_game_rounds_on_challenge_id"
+    t.index ["game_id"], name: "index_game_rounds_on_game_id"
+    t.index ["round_winner_id"], name: "index_game_rounds_on_round_winner_id"
+  end
+
+  create_table "games", force: :cascade do |t|
+    t.bigint "challenger_id", null: false
+    t.bigint "opponent_id", null: false
+    t.bigint "winner_id"
+    t.integer "status", default: 0, null: false
+    t.integer "round_count", null: false
+    t.integer "difficulty", null: false
+    t.datetime "started_at"
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["challenger_id"], name: "index_games_on_challenger_id"
+    t.index ["opponent_id"], name: "index_games_on_opponent_id"
+    t.index ["winner_id"], name: "index_games_on_winner_id"
+  end
+
   create_table "invitations", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.integer "friend_id"
@@ -198,6 +229,12 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_30_182123) do
   add_foreign_key "duels", "users", column: "challenger_id"
   add_foreign_key "duels", "users", column: "opponent_id"
   add_foreign_key "duels", "users", column: "winner_id"
+  add_foreign_key "game_rounds", "challenges"
+  add_foreign_key "game_rounds", "games"
+  add_foreign_key "game_rounds", "users", column: "round_winner_id"
+  add_foreign_key "games", "users", column: "challenger_id"
+  add_foreign_key "games", "users", column: "opponent_id"
+  add_foreign_key "games", "users", column: "winner_id"
   add_foreign_key "invitations", "users"
   add_foreign_key "notifications", "users"
   add_foreign_key "posts", "discussions"

--- a/test/models/game_round_test.rb
+++ b/test/models/game_round_test.rb
@@ -1,0 +1,87 @@
+require "test_helper"
+
+class GameRoundTest < ActiveSupport::TestCase
+  def setup
+    @challenger = User.create!(
+      email: "ch_#{SecureRandom.hex(4)}@example.com", password: "password",
+      first_name: "Alice", last_name: "C", score: 100
+    )
+    @opponent = User.create!(
+      email: "op_#{SecureRandom.hex(4)}@example.com", password: "password",
+      first_name: "Bob", last_name: "O", score: 80
+    )
+    @challenge = Challenge.create!(
+      name: "ch_#{SecureRandom.hex(4)}", difficulty: :easy,
+      language: "ruby", tests: [], method_template: "def foo\nend"
+    )
+    @game = Game.create!(
+      challenger: @challenger, opponent: @opponent,
+      round_count: :one, difficulty: :easy, status: :active
+    )
+    @round = GameRound.create!(
+      game: @game, challenge: @challenge, round_number: 1
+    )
+  end
+
+  test "complete! sets round_winner" do
+    @round.complete!(winner: @challenger)
+    assert_equal @challenger, @round.round_winner
+  end
+
+  test "complete! sets completed_at" do
+    @round.complete!(winner: @challenger)
+    assert_not_nil @round.completed_at
+  end
+
+  test "complete! marks game as completed when majority reached" do
+    @round.complete!(winner: @challenger)
+    assert @game.reload.completed?
+  end
+
+  test "complete! sets game winner" do
+    @round.complete!(winner: @challenger)
+    assert_equal @challenger, @game.reload.winner
+  end
+
+  test "complete! sets game completed_at" do
+    @round.complete!(winner: @challenger)
+    assert_not_nil @game.reload.completed_at
+  end
+
+  test "complete! does not complete game until majority in 3-round game" do
+    game = Game.create!(
+      challenger: @challenger, opponent: @opponent,
+      round_count: :three, difficulty: :easy, status: :active
+    )
+    r1 = GameRound.create!(game: game, challenge: @challenge, round_number: 1)
+    r1.complete!(winner: @challenger)
+    assert game.reload.active?
+  end
+
+  test "complete! completes 3-round game when challenger wins 2nd round" do
+    game = Game.create!(
+      challenger: @challenger, opponent: @opponent,
+      round_count: :three, difficulty: :easy, status: :active
+    )
+    r1 = GameRound.create!(game: game, challenge: @challenge, round_number: 1)
+    r2 = GameRound.create!(game: game, challenge: @challenge, round_number: 2)
+
+    r1.complete!(winner: @challenger)
+    assert game.reload.active?
+
+    r2.complete!(winner: @challenger)
+    assert game.reload.completed?
+    assert_equal @challenger, game.reload.winner
+  end
+
+  test "complete! updates winner score on game completion" do
+    initial = @challenger.score
+    @round.complete!(winner: @challenger)
+    assert_equal initial + 8, @challenger.reload.score
+  end
+
+  test "complete! does not change loser score when loser won zero rounds" do
+    @round.complete!(winner: @challenger)
+    assert_equal 80, @opponent.reload.score
+  end
+end

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -1,0 +1,139 @@
+require "test_helper"
+
+class GameTest < ActiveSupport::TestCase
+  def setup
+    @challenger = User.create!(
+      email: "challenger@example.com", password: "password",
+      first_name: "Alice", last_name: "Challenger"
+    )
+    @opponent = User.create!(
+      email: "opponent@example.com", password: "password",
+      first_name: "Bob", last_name: "Opponent"
+    )
+    @challenge = Challenge.create!(
+      name: "test_challenge_#{SecureRandom.hex(4)}", difficulty: :easy,
+      language: "ruby", tests: [], method_template: "def foo\nend"
+    )
+    @game = Game.create!(
+      challenger: @challenger, opponent: @opponent,
+      round_count: :one, difficulty: :easy
+    )
+  end
+
+  test "status defaults to pending" do
+    assert @game.pending?
+  end
+
+  test "status transitions pending -> active -> completed" do
+    @game.active!
+    assert @game.active?
+    @game.completed!
+    assert @game.completed?
+  end
+
+  test "belongs_to challenger and opponent" do
+    assert_equal @challenger, @game.challenger
+    assert_equal @opponent,   @game.opponent
+  end
+
+  test "winner is optional" do
+    assert_nil @game.winner
+  end
+
+  test "winner_of_game returns nil with no completed rounds" do
+    assert_nil @game.winner_of_game
+  end
+
+  test "winner_of_game returns challenger after winning 1-round game" do
+    GameRound.create!(
+      game: @game, challenge: @challenge, round_number: 1,
+      round_winner: @challenger, completed_at: Time.current
+    )
+    assert_equal @challenger, @game.winner_of_game
+  end
+
+  test "winner_of_game returns nil when no majority yet in 3-round game" do
+    game = Game.create!(
+      challenger: @challenger, opponent: @opponent,
+      round_count: :three, difficulty: :easy
+    )
+    GameRound.create!(
+      game: game, challenge: @challenge, round_number: 1,
+      round_winner: @challenger, completed_at: Time.current
+    )
+    assert_nil game.winner_of_game
+  end
+
+  test "winner_of_game returns winner when majority reached in 3-round game" do
+    game = Game.create!(
+      challenger: @challenger, opponent: @opponent,
+      round_count: :three, difficulty: :easy
+    )
+    GameRound.create!(
+      game: game, challenge: @challenge, round_number: 1,
+      round_winner: @challenger, completed_at: Time.current
+    )
+    GameRound.create!(
+      game: game, challenge: @challenge, round_number: 2,
+      round_winner: @challenger, completed_at: Time.current
+    )
+    assert_equal @challenger, game.winner_of_game
+  end
+
+  test "winner_of_game returns winner at majority in 5-round game" do
+    game = Game.create!(
+      challenger: @challenger, opponent: @opponent,
+      round_count: :five, difficulty: :easy
+    )
+    [1, 2].each do |n|
+      GameRound.create!(
+        game: game, challenge: @challenge, round_number: n,
+        round_winner: @opponent, completed_at: Time.current
+      )
+    end
+    assert_nil game.winner_of_game
+
+    GameRound.create!(
+      game: game, challenge: @challenge, round_number: 3,
+      round_winner: @opponent, completed_at: Time.current
+    )
+    assert_equal @opponent, game.winner_of_game
+  end
+
+  test "apply_scores! increases winner score" do
+    @challenger.update!(score: 0)
+    @opponent.update!(score: 80)
+    GameRound.create!(
+      game: @game, challenge: @challenge, round_number: 1,
+      round_winner: @challenger, completed_at: Time.current
+    )
+    @game.apply_scores!
+    assert_equal 8, @challenger.reload.score
+  end
+
+  test "apply_scores! increases loser score when they won rounds" do
+    @challenger.update!(score: 0)
+    @opponent.update!(score: 0)
+    game = Game.create!(
+      challenger: @challenger, opponent: @opponent,
+      round_count: :three, difficulty: :easy
+    )
+    GameRound.create!(game: game, challenge: @challenge, round_number: 1,
+      round_winner: @challenger, completed_at: Time.current)
+    GameRound.create!(game: game, challenge: @challenge, round_number: 2,
+      round_winner: @opponent, completed_at: Time.current)
+    GameRound.create!(game: game, challenge: @challenge, round_number: 3,
+      round_winner: @challenger, completed_at: Time.current)
+    game.apply_scores!
+    assert_equal 4, @challenger.reload.score
+    assert_equal 1, @opponent.reload.score
+  end
+
+  test "apply_scores! does nothing when no majority winner" do
+    @challenger.update!(score: 10)
+    @opponent.update!(score: 10)
+    @game.apply_scores!
+    assert_equal 10, @challenger.reload.score
+    assert_equal 10, @opponent.reload.score
+  end
+end

--- a/test/services/game_scorer_test.rb
+++ b/test/services/game_scorer_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class GameScorerTest < ActiveSupport::TestCase
+  test "score_for_winner: 1-round sweep, opponent at 0" do
+    assert_equal 4, GameScorer.score_for_winner(rounds_won: 1, rounds_lost: 0, opponent_score: 0)
+  end
+
+  test "score_for_winner: includes opponent score bonus below cap" do
+    assert_equal 9, GameScorer.score_for_winner(rounds_won: 2, rounds_lost: 1, opponent_score: 100)
+  end
+
+  test "score_for_winner: caps opponent bonus at 50 when score is high" do
+    assert_equal 55, GameScorer.score_for_winner(rounds_won: 2, rounds_lost: 0, opponent_score: 1100)
+  end
+
+  test "score_for_winner: bonus exactly at cap (opponent_score=1000)" do
+    assert_equal 55, GameScorer.score_for_winner(rounds_won: 2, rounds_lost: 0, opponent_score: 1000)
+  end
+
+  test "score_for_winner: bonus just below cap (opponent_score=980)" do
+    assert_equal 54, GameScorer.score_for_winner(rounds_won: 2, rounds_lost: 0, opponent_score: 980)
+  end
+
+  test "score_for_winner: rounds_lost reduces score" do
+    assert_equal 4, GameScorer.score_for_winner(rounds_won: 3, rounds_lost: 2, opponent_score: 0)
+  end
+
+  test "score_for_loser: returns rounds_won when positive" do
+    assert_equal 2, GameScorer.score_for_loser(rounds_won: 2)
+  end
+
+  test "score_for_loser: returns 0 when no rounds won" do
+    assert_equal 0, GameScorer.score_for_loser(rounds_won: 0)
+  end
+end


### PR DESCRIPTION
## Summary
- Add `games` and `game_rounds` migrations with correct columns, enums, and foreign keys
- Implement `Game` model with status enum (pending/active/completed), `winner_of_game` (majority detection), and `apply_scores!` (atomic score update via transaction)
- Implement `GameRound` model with `complete!(winner:)` which drives the state machine and triggers game completion
- Add `GameScorer` plain Ruby service (no ActiveRecord) with `score_for_winner` and `score_for_loser` class methods

## Test Plan
- [x] 8 `GameScorer` unit tests pass (all boundary cases including opponent score cap at 50)
- [x] 12 `Game` model tests pass (status transitions, `winner_of_game` for 1/3/5 round games, `apply_scores!`)
- [x] 9 `GameRound` model tests pass (`complete!` end-to-end including score updates)

Closes #17