### PR TITLE
feat: Multi-round Game System (Issues #18–#23)

### DIFF
--- a/app/channels/game_channel.rb
+++ b/app/channels/game_channel.rb
@@ -1,0 +1,9 @@
+class GameChannel < ApplicationCable::Channel
+  def subscribed
+    game = Game.find_by(id: params[:game_id])
+    stream_from "game_#{game.id}" if game&.participant?(current_user)
+  end
+
+  def unsubscribed
+  end
+end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,0 +1,116 @@
+class GamesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_game, only: %i[show accept decline broadcast_code round_won]
+
+  def new
+    @friends = current_user.friends
+  end
+
+  def create
+    @opponent    = User.find(params[:opponent_id])
+    rc_key       = params[:round_count].to_s
+    difficulty   = params[:difficulty].to_s
+    actual_count = Game::ROUND_COUNT_NUM[rc_key] || 1
+
+    return redirect_to root_path, alert: "You can only challenge friends." unless current_user.friend_with?(@opponent)
+
+    challenges = Challenge.where(difficulty: difficulty).order("RANDOM()").limit(actual_count)
+    if challenges.size < actual_count
+      @friends = current_user.friends
+      flash.now[:alert] = "Not enough #{difficulty} challenges available."
+      return render :new, status: :unprocessable_entity
+    end
+
+    @game = Game.create!(
+      challenger:  current_user,
+      opponent:    @opponent,
+      round_count: rc_key,
+      difficulty:  difficulty
+    )
+
+    challenges.each_with_index do |challenge, i|
+      @game.game_rounds.create!(challenge: challenge, round_number: i + 1)
+    end
+
+    GameInviteNotification.create!(
+      user:   @opponent,
+      params: { game_id: @game.id, challenger_name: current_user.full_name, round_count: actual_count }
+    )
+
+    redirect_to game_path(@game), notice: "Challenge sent to #{@opponent.first_name}!"
+  end
+
+  def show
+    return redirect_to root_path unless @game.participant?(current_user)
+    @current_round = @game.game_rounds.ordered.find { |r| r.round_winner_id.nil? }
+    @rounds        = @game.game_rounds.ordered.includes(:challenge, :round_winner)
+  end
+
+  def accept
+    return redirect_to game_path(@game) unless @game.opponent == current_user && @game.pending?
+    @game.update!(status: :active, started_at: Time.current)
+    ActionCable.server.broadcast("game_#{@game.id}", { type: "game_started" })
+    redirect_to game_path(@game)
+  end
+
+  def decline
+    return redirect_to root_path unless @game.opponent == current_user && @game.pending?
+    ActionCable.server.broadcast("game_#{@game.id}", { type: "game_declined" })
+    @game.destroy
+    redirect_to root_path, notice: "Game declined."
+  end
+
+  def broadcast_code
+    return head :forbidden unless @game.active? && @game.participant?(current_user)
+    ActionCable.server.broadcast("game_#{@game.id}", {
+      type: "code_update", code: params[:code], user_id: current_user.id
+    })
+    head :ok
+  end
+
+  def round_won
+    return head :forbidden unless @game.active? && @game.participant?(current_user)
+    round = @game.game_rounds.find_by(id: params[:round_id])
+    return head :not_found unless round
+    return head :ok        if round.completed_at.present?
+
+    if @game.challenger == current_user
+      round.update_column(:challenger_code, params[:code])
+    else
+      round.update_column(:opponent_code, params[:code])
+    end
+
+    round.complete!(winner: current_user)
+    @game.reload
+
+    if @game.completed?
+      [@game.challenger, @game.opponent].each do |player|
+        opp_name = player == @game.challenger ? @game.opponent.full_name : @game.challenger.full_name
+        GameResultNotification.create!(
+          user:   player,
+          params: { game_id: @game.id, winner_id: @game.winner_id, opponent_name: opp_name }
+        )
+      end
+      ActionCable.server.broadcast("game_#{@game.id}", {
+        type: "game_completed", winner_id: @game.winner_id, winner_name: @game.winner.full_name
+      })
+    else
+      next_round = @game.game_rounds.ordered.find { |r| r.round_winner_id.nil? }
+      ActionCable.server.broadcast("game_#{@game.id}", {
+        type: "round_completed",
+        round_number: round.round_number,
+        winner_id: current_user.id,
+        winner_name: current_user.full_name,
+        next_round_number: next_round&.round_number
+      })
+    end
+
+    head :ok
+  end
+
+  private
+
+  def set_game
+    @game = Game.find(params[:id])
+  end
+end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -7,9 +7,9 @@ class GamesController < ApplicationController
   end
 
   def create
-    @opponent    = User.find(params[:opponent_id])
-    rc_key       = params[:round_count].to_s
-    difficulty   = params[:difficulty].to_s
+    @opponent  = User.find(params[:opponent_id])
+    rc_key     = params[:round_count].to_s
+    difficulty = params[:difficulty].to_s
     actual_count = Game::ROUND_COUNT_NUM[rc_key] || 1
 
     return redirect_to root_path, alert: "You can only challenge friends." unless current_user.friend_with?(@opponent)
@@ -70,6 +70,7 @@ class GamesController < ApplicationController
 
   def round_won
     return head :forbidden unless @game.active? && @game.participant?(current_user)
+
     round = @game.game_rounds.find_by(id: params[:round_id])
     return head :not_found unless round
     return head :ok        if round.completed_at.present?
@@ -84,23 +85,25 @@ class GamesController < ApplicationController
     @game.reload
 
     if @game.completed?
-      [@game.challenger, @game.opponent].each do |player|
-        opp_name = player == @game.challenger ? @game.opponent.full_name : @game.challenger.full_name
+      [ @game.challenger, @game.opponent ].each do |player|
+        opp = player == @game.challenger ? @game.opponent : @game.challenger
         GameResultNotification.create!(
           user:   player,
-          params: { game_id: @game.id, winner_id: @game.winner_id, opponent_name: opp_name }
+          params: { game_id: @game.id, winner_id: @game.winner_id, opponent_name: opp.full_name }
         )
       end
       ActionCable.server.broadcast("game_#{@game.id}", {
-        type: "game_completed", winner_id: @game.winner_id, winner_name: @game.winner.full_name
+        type:        "game_completed",
+        winner_id:   @game.winner_id,
+        winner_name: @game.winner.full_name
       })
     else
       next_round = @game.game_rounds.ordered.find { |r| r.round_winner_id.nil? }
       ActionCable.server.broadcast("game_#{@game.id}", {
-        type: "round_completed",
-        round_number: round.round_number,
-        winner_id: current_user.id,
-        winner_name: current_user.full_name,
+        type:              "round_completed",
+        round_number:      round.round_number,
+        winner_id:         current_user.id,
+        winner_name:       current_user.full_name,
         next_round_number: next_round&.round_number
       })
     end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,6 +6,7 @@ class HomeController < ApplicationController
     @friends = current_user.friends
     @featured_challenges = Challenge.order(:difficulty).limit(3)
 
-    @new_user = @friends.empty? && @challenges_solved.zero?
+    @new_user    = @friends.empty? && @challenges_solved.zero?
+    @leaderboard = User.top_10_by_score
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,11 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find_by(slug: params[:slug])
-    @users = User.all
-    redirect_to root_path, alert: "Sorry unable to find a user for this link #{params[:slug]}" unless @user
+    redirect_to root_path, alert: "Sorry unable to find a user for this link #{params[:slug]}" and return unless @user
+    @game_history = Game.where("challenger_id = :id OR opponent_id = :id", id: @user.id)
+                        .where(status: Game.statuses[:completed])
+                        .includes(:challenger, :opponent, :winner, game_rounds: :challenge)
+                        .order(completed_at: :desc)
+                        .limit(10)
   end
 end

--- a/app/javascript/controllers/game_controller.js
+++ b/app/javascript/controllers/game_controller.js
@@ -1,0 +1,150 @@
+import { Controller } from "@hotwired/stimulus"
+import { createConsumer } from "@rails/actioncable"
+
+export default class extends Controller {
+  static targets = ["editor", "output", "runBtn", "myScore", "opponentScore"]
+  static values  = { gameId: String, currentUserId: Number, challengeId: String, roundId: String }
+
+  connect() {
+    const codeEditorEl = document.getElementById("code-editor")
+
+    if (codeEditorEl) {
+      const methodTemplate = codeEditorEl.dataset.methodTemplate?.replaceAll("\\n", "\n") || ""
+      this.editor = CodeMirror.fromTextArea(this.editorTarget, {
+        mode: "ruby",
+        lineNumbers: true,
+        indentUnit: 2,
+        tabSize: 2,
+        lineWrapping: true,
+        autofocus: true
+      })
+      this.editor.setValue(methodTemplate)
+      this.editor.getWrapperElement().style.height = "360px"
+      this.editor.on("change", () => this._debouncedBroadcast())
+    }
+
+    this._broadcastTimer = null
+
+    this.subscription = createConsumer().subscriptions.create(
+      { channel: "GameChannel", game_id: this.gameIdValue },
+      { received: (data) => this.handleBroadcast(data) }
+    )
+  }
+
+  disconnect() {
+    this.subscription?.unsubscribe()
+  }
+
+  get code() {
+    return this.editor?.getValue() || ""
+  }
+
+  get csrfToken() {
+    return document.querySelector('meta[name="csrf-token"]')?.content
+  }
+
+  async run() {
+    if (!this.editor) return
+    this.runBtnTarget.textContent = "Running…"
+    this.runBtnTarget.disabled = true
+
+    try {
+      const resp = await fetch("/evaluate_code", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-CSRF-Token": this.csrfToken },
+        body: JSON.stringify({ code: this.code, id: this.challengeIdValue, game_id: this.gameIdValue })
+      })
+      const result = await resp.json()
+      this.renderResult(result)
+
+      const allPassed = result.output && Object.values(result.output).every(r => r.passed)
+      if (allPassed && !result.error) this.signalRoundWon()
+    } catch (err) {
+      this.outputTarget.textContent = `Error: ${err.message}`
+    } finally {
+      this.runBtnTarget.textContent = "Run Tests ▶"
+      this.runBtnTarget.disabled = false
+    }
+  }
+
+  async signalRoundWon() {
+    await fetch(`/games/${this.gameIdValue}/round_won`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-CSRF-Token": this.csrfToken },
+      body: JSON.stringify({ round_id: this.roundIdValue, code: this.code })
+    })
+  }
+
+  _debouncedBroadcast() {
+    clearTimeout(this._broadcastTimer)
+    this._broadcastTimer = setTimeout(() => this.broadcastCode(), 400)
+  }
+
+  async broadcastCode() {
+    await fetch(`/games/${this.gameIdValue}/broadcast_code`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-CSRF-Token": this.csrfToken },
+      body: JSON.stringify({ code: this.code })
+    })
+  }
+
+  handleBroadcast(data) {
+    if (data.type === "game_started") {
+      window.location.reload()
+    } else if (data.type === "game_declined") {
+      window.location.href = "/"
+    } else if (data.type === "round_completed") {
+      if (data.winner_id === this.currentUserIdValue) {
+        if (this.hasMyScoreTarget) this.myScoreTarget.textContent = parseInt(this.myScoreTarget.textContent) + 1
+      } else {
+        if (this.hasOpponentScoreTarget) this.opponentScoreTarget.textContent = parseInt(this.opponentScoreTarget.textContent) + 1
+      }
+      if (data.next_round_number) {
+        setTimeout(() => window.location.reload(), 1500)
+      }
+    } else if (data.type === "game_completed") {
+      this.showGameResult(data.winner_id, data.winner_name)
+    }
+  }
+
+  showGameResult(winnerId, winnerName) {
+    const banner = document.getElementById("game-banner")
+    if (!banner) return
+    if (winnerId === this.currentUserIdValue) {
+      banner.textContent = "🏆 You won the game!"
+      banner.style.color = "#a6d6ff"
+    } else {
+      banner.textContent = `${winnerName} won the game.`
+      banner.style.color = "var(--ck-muted)"
+    }
+    banner.classList.remove("hidden")
+    banner.scrollIntoView({ behavior: "smooth" })
+    setTimeout(() => window.location.reload(), 3000)
+  }
+
+  renderResult({ error, output }) {
+    if (error) {
+      this.outputTarget.textContent = `Error: ${error}`
+      return
+    }
+    const lines = Object.entries(output).map(([input, { expected, actual, passed }]) =>
+      `Test: ${input}\nExpected: ${expected}\nActual:   ${actual}\n${passed ? "✅ Passed" : "❌ Failed"}`
+    ).join("\n\n")
+    this.outputTarget.textContent = lines || "No output"
+  }
+
+  async hint() {
+    this.outputTarget.textContent = "Fetching hint…"
+    try {
+      const resp = await fetch("/hints", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-CSRF-Token": this.csrfToken },
+        body: JSON.stringify({ challenge_id: this.challengeIdValue, code: this.code })
+      })
+      const result = await resp.json()
+      this.outputTarget.textContent = result.hint || result.error || "No hint available."
+    } catch (err) {
+      this.outputTarget.textContent = `Error fetching hint: ${err.message}`
+    }
+  }
+}

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -9,15 +9,18 @@ class Game < ApplicationRecord
   enum :round_count, { one: 0, three: 1, five: 2 }
   enum :difficulty,  { easy: 0, medium: 1, hard: 2 }
 
-  ROUNDS_TO_WIN = { "one" => 1, "three" => 2, "five" => 3 }.freeze
+  ROUNDS_TO_WIN   = { "one" => 1, "three" => 2, "five" => 3 }.freeze
+  ROUND_COUNT_NUM = { "one" => 1, "three" => 3, "five" => 5 }.freeze
+
+  def participant?(user)
+    challenger_id == user.id || opponent_id == user.id
+  end
 
   def winner_of_game
-    wins = game_rounds.where.not(round_winner_id: nil).group(:round_winner_id).count
+    wins   = game_rounds.where.not(round_winner_id: nil).group(:round_winner_id).count
     target = ROUNDS_TO_WIN[round_count]
-
     winner_id, count = wins.max_by { |_, c| c }
     return nil if count.nil? || count < target
-
     [ challenger, opponent ].find { |u| u.id == winner_id }
   end
 
@@ -25,9 +28,8 @@ class Game < ApplicationRecord
     game_winner = winner_of_game
     return unless game_winner
 
-    loser = game_winner == challenger ? opponent : challenger
-    completed = game_rounds.where.not(round_winner_id: nil)
-
+    loser         = game_winner == challenger ? opponent : challenger
+    completed     = game_rounds.where.not(round_winner_id: nil)
     winner_rounds = completed.where(round_winner_id: game_winner.id).count
     loser_rounds  = completed.where(round_winner_id: loser.id).count
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -17,10 +17,12 @@ class Game < ApplicationRecord
   end
 
   def winner_of_game
-    wins   = game_rounds.where.not(round_winner_id: nil).group(:round_winner_id).count
+    wins = game_rounds.where.not(round_winner_id: nil).group(:round_winner_id).count
     target = ROUNDS_TO_WIN[round_count]
+
     winner_id, count = wins.max_by { |_, c| c }
     return nil if count.nil? || count < target
+
     [ challenger, opponent ].find { |u| u.id == winner_id }
   end
 
@@ -28,8 +30,9 @@ class Game < ApplicationRecord
     game_winner = winner_of_game
     return unless game_winner
 
-    loser         = game_winner == challenger ? opponent : challenger
-    completed     = game_rounds.where.not(round_winner_id: nil)
+    loser = game_winner == challenger ? opponent : challenger
+    completed = game_rounds.where.not(round_winner_id: nil)
+
     winner_rounds = completed.where(round_winner_id: game_winner.id).count
     loser_rounds  = completed.where(round_winner_id: loser.id).count
 

--- a/app/notifications/game_invite_notification.rb
+++ b/app/notifications/game_invite_notification.rb
@@ -1,6 +1,6 @@
 class GameInviteNotification < Notification
   def message
-    "#{params["challenger_name"]} has challenged you to a #{params["round_count"]}-round Game"
+    "#{params["challenger_name"]} challenged you to a #{params["round_count"]}-round Game"
   end
 
   def url

--- a/app/notifications/game_invite_notification.rb
+++ b/app/notifications/game_invite_notification.rb
@@ -1,0 +1,9 @@
+class GameInviteNotification < Notification
+  def message
+    "#{params["challenger_name"]} has challenged you to a #{params["round_count"]}-round Game"
+  end
+
+  def url
+    "/games/#{params["game_id"]}"
+  end
+end

--- a/app/notifications/game_result_notification.rb
+++ b/app/notifications/game_result_notification.rb
@@ -1,0 +1,13 @@
+class GameResultNotification < Notification
+  def message
+    if params["winner_id"] == user_id
+      "You beat #{params["opponent_name"]}! Game complete."
+    else
+      "#{params["opponent_name"]} won the game. Better luck next time!"
+    end
+  end
+
+  def url
+    "/games/#{params["game_id"]}"
+  end
+end

--- a/app/views/games/new.html.erb
+++ b/app/views/games/new.html.erb
@@ -1,69 +1,66 @@
 <div class="px-12 py-9">
   <div class="mb-8">
-    <div class="ck-meta mb-1">Games · New Challenge</div>
+    <div class="ck-meta mb-1">Games</div>
     <div class="ck-heading">Challenge a Friend</div>
-    <p class="ck-meta mt-1">First to pass all tests in a round wins it. Win the majority to win the Game.</p>
   </div>
 
-  <%= form_with url: games_path, method: :post do |f| %>
-    <div class="ck-card mb-4" style="border-radius: 10px;">
-      <div class="ck-meta mb-3">Select Opponent</div>
-      <% if @friends.any? %>
-        <div class="space-y-2">
-          <% @friends.each do |friend| %>
-            <label class="flex items-center gap-3 p-3 rounded-lg cursor-pointer" style="border: 0.5px solid var(--ck-line);">
-              <%= f.radio_button :opponent_id, friend.id, required: true %>
-              <div class="flex items-center gap-3">
-                <div class="w-8 h-8 rounded-full flex items-center justify-center text-[11px] font-semibold shrink-0" style="background: var(--ck-raised);">
-                  <% if friend.avatar.attached? %>
-                    <%= image_tag friend.avatar, class: "w-8 h-8 object-cover rounded-full" %>
-                  <% else %>
-                    <%= friend.initials %>
-                  <% end %>
-                </div>
-                <div>
-                  <div class="text-[14px] font-medium"><%= friend.full_name %></div>
-                  <div class="ck-meta text-[10px]">Score: <%= friend.score %></div>
-                </div>
-              </div>
-            </label>
-          <% end %>
-        </div>
-      <% else %>
-        <p class="ck-meta">
-          No friends yet.
-          <%= link_to "Send an invitation", invitations_path, style: "color: #a6d6ff;" %> to unlock Games.
-        </p>
+  <div class="ck-card" style="max-width: 480px;">
+    <%= form_with url: games_path, method: :post do |f| %>
+      <% if flash[:alert] %>
+        <div class="mb-4 text-[13px]" style="color: #f87171;"><%= flash[:alert] %></div>
       <% end %>
-    </div>
 
-    <div class="grid grid-cols-2 gap-4 mb-6">
-      <div class="ck-card" style="border-radius: 10px;">
-        <div class="ck-meta mb-3">Rounds</div>
-        <div class="space-y-2">
-          <% [["one", "1 Round"], ["three", "3 Rounds"], ["five", "5 Rounds"]].each do |(key, label)| %>
-            <label class="flex items-center gap-2 cursor-pointer">
-              <%= f.radio_button :round_count, key, required: true %>
-              <span class="text-[13px]"><%= label %></span>
+      <div class="mb-5">
+        <div class="ck-meta mb-2">Opponent</div>
+        <% if @friends.any? %>
+          <select name="opponent_id" class="w-full text-[13px] px-3 py-2 rounded-lg outline-none"
+                  style="background: var(--ck-raised); color: var(--ck-ink); border: 1px solid var(--ck-line);">
+            <% @friends.each do |friend| %>
+              <option value="<%= friend.id %>"><%= friend.full_name %></option>
+            <% end %>
+          </select>
+        <% else %>
+          <p class="text-[13px]" style="color: var(--ck-muted);">
+            No friends yet. <%= link_to "Send invitations", invitations_path, style: "color: #a6d6ff;" %> first.
+          </p>
+        <% end %>
+      </div>
+
+      <div class="mb-5">
+        <div class="ck-meta mb-2">Rounds</div>
+        <div class="flex gap-2">
+          <% [["1 Round", "one"], ["3 Rounds", "three"], ["5 Rounds", "five"]].each do |label, val| %>
+            <label class="flex-1 text-center text-[13px] px-3 py-2 rounded-lg cursor-pointer transition-colors"
+                   style="background: var(--ck-raised); color: var(--ck-muted); border: 1px solid var(--ck-line);"
+                   onmouseover="this.style.borderColor='#a6d6ff'" onmouseout="if(!this.querySelector('input').checked) this.style.borderColor='var(--ck-line)'">
+              <input type="radio" name="round_count" value="<%= val %>" class="hidden"
+                     <%= "checked" if val == "one" %>
+                     onchange="document.querySelectorAll('[name=round_count]').forEach(r => { r.parentElement.style.color='var(--ck-muted)'; r.parentElement.style.borderColor='var(--ck-line)'; }); this.parentElement.style.color='#a6d6ff'; this.parentElement.style.borderColor='#a6d6ff';">
+              <%= label %>
             </label>
           <% end %>
         </div>
       </div>
-      <div class="ck-card" style="border-radius: 10px;">
-        <div class="ck-meta mb-3">Difficulty</div>
-        <div class="space-y-2">
-          <% [["easy", "Easy"], ["medium", "Medium"], ["hard", "Hard"]].each do |(key, label)| %>
-            <label class="flex items-center gap-2 cursor-pointer">
-              <%= f.radio_button :difficulty, key, required: true %>
-              <span class="ck-chip ck-chip--<%= key %>"><%= label %></span>
+
+      <div class="mb-6">
+        <div class="ck-meta mb-2">Difficulty</div>
+        <div class="flex gap-2">
+          <% [["Easy", "easy"], ["Medium", "medium"], ["Hard", "hard"]].each do |label, val| %>
+            <label class="flex-1 text-center text-[13px] px-3 py-2 rounded-lg cursor-pointer transition-colors"
+                   style="background: var(--ck-raised); color: var(--ck-muted); border: 1px solid var(--ck-line);"
+                   onmouseover="this.style.borderColor='#a6d6ff'" onmouseout="if(!this.querySelector('input').checked) this.style.borderColor='var(--ck-line)'">
+              <input type="radio" name="difficulty" value="<%= val %>" class="hidden"
+                     <%= "checked" if val == "easy" %>
+                     onchange="document.querySelectorAll('[name=difficulty]').forEach(r => { r.parentElement.style.color='var(--ck-muted)'; r.parentElement.style.borderColor='var(--ck-line)'; }); this.parentElement.style.color='#a6d6ff'; this.parentElement.style.borderColor='#a6d6ff';">
+              <%= label %>
             </label>
           <% end %>
         </div>
       </div>
-    </div>
 
-    <% if @friends.any? %>
-      <%= f.submit "Send Challenge →", class: "ck-btn-primary", style: "cursor: pointer;" %>
+      <% if @friends.any? %>
+        <%= f.submit "Send Challenge", class: "ck-btn-primary w-full cursor-pointer" %>
+      <% end %>
     <% end %>
-  <% end %>
+  </div>
 </div>

--- a/app/views/games/new.html.erb
+++ b/app/views/games/new.html.erb
@@ -1,0 +1,69 @@
+<div class="px-12 py-9">
+  <div class="mb-8">
+    <div class="ck-meta mb-1">Games · New Challenge</div>
+    <div class="ck-heading">Challenge a Friend</div>
+    <p class="ck-meta mt-1">First to pass all tests in a round wins it. Win the majority to win the Game.</p>
+  </div>
+
+  <%= form_with url: games_path, method: :post do |f| %>
+    <div class="ck-card mb-4" style="border-radius: 10px;">
+      <div class="ck-meta mb-3">Select Opponent</div>
+      <% if @friends.any? %>
+        <div class="space-y-2">
+          <% @friends.each do |friend| %>
+            <label class="flex items-center gap-3 p-3 rounded-lg cursor-pointer" style="border: 0.5px solid var(--ck-line);">
+              <%= f.radio_button :opponent_id, friend.id, required: true %>
+              <div class="flex items-center gap-3">
+                <div class="w-8 h-8 rounded-full flex items-center justify-center text-[11px] font-semibold shrink-0" style="background: var(--ck-raised);">
+                  <% if friend.avatar.attached? %>
+                    <%= image_tag friend.avatar, class: "w-8 h-8 object-cover rounded-full" %>
+                  <% else %>
+                    <%= friend.initials %>
+                  <% end %>
+                </div>
+                <div>
+                  <div class="text-[14px] font-medium"><%= friend.full_name %></div>
+                  <div class="ck-meta text-[10px]">Score: <%= friend.score %></div>
+                </div>
+              </div>
+            </label>
+          <% end %>
+        </div>
+      <% else %>
+        <p class="ck-meta">
+          No friends yet.
+          <%= link_to "Send an invitation", invitations_path, style: "color: #a6d6ff;" %> to unlock Games.
+        </p>
+      <% end %>
+    </div>
+
+    <div class="grid grid-cols-2 gap-4 mb-6">
+      <div class="ck-card" style="border-radius: 10px;">
+        <div class="ck-meta mb-3">Rounds</div>
+        <div class="space-y-2">
+          <% [["one", "1 Round"], ["three", "3 Rounds"], ["five", "5 Rounds"]].each do |(key, label)| %>
+            <label class="flex items-center gap-2 cursor-pointer">
+              <%= f.radio_button :round_count, key, required: true %>
+              <span class="text-[13px]"><%= label %></span>
+            </label>
+          <% end %>
+        </div>
+      </div>
+      <div class="ck-card" style="border-radius: 10px;">
+        <div class="ck-meta mb-3">Difficulty</div>
+        <div class="space-y-2">
+          <% [["easy", "Easy"], ["medium", "Medium"], ["hard", "Hard"]].each do |(key, label)| %>
+            <label class="flex items-center gap-2 cursor-pointer">
+              <%= f.radio_button :difficulty, key, required: true %>
+              <span class="ck-chip ck-chip--<%= key %>"><%= label %></span>
+            </label>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <% if @friends.any? %>
+      <%= f.submit "Send Challenge →", class: "ck-btn-primary", style: "cursor: pointer;" %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,0 +1,193 @@
+<% if @game.pending? %>
+  <%# ── Pending lobby ─────────────────────────────────── %>
+  <div
+    id="game-lobby"
+    data-controller="game"
+    data-game-game-id-value="<%= @game.id %>"
+    data-game-current-user-id-value="<%= current_user.id %>"
+    class="px-12 py-9"
+  >
+    <div class="mb-8">
+      <div class="ck-meta mb-1">Game · Pending</div>
+      <div class="ck-heading">Waiting Room</div>
+    </div>
+
+    <div class="ck-card" style="max-width: 480px;">
+      <div class="flex items-center gap-4 mb-6">
+        <div class="w-10 h-10 rounded-full flex items-center justify-center text-[13px] font-semibold shrink-0" style="background: var(--ck-raised); color: var(--ck-ink);">
+          <%= @game.challenger.initials %>
+        </div>
+        <div>
+          <div class="text-[14px] font-medium"><%= @game.challenger.full_name %></div>
+          <div class="ck-meta">Challenger</div>
+        </div>
+        <div class="mx-4 ck-meta">vs</div>
+        <div class="w-10 h-10 rounded-full flex items-center justify-center text-[13px] font-semibold shrink-0" style="background: var(--ck-raised); color: var(--ck-ink);">
+          <%= @game.opponent.initials %>
+        </div>
+        <div>
+          <div class="text-[14px] font-medium"><%= @game.opponent.full_name %></div>
+          <div class="ck-meta">Opponent</div>
+        </div>
+      </div>
+
+      <div class="flex gap-3 ck-meta mb-6">
+        <span class="ck-chip"><%= Game::ROUND_COUNT_NUM[@game.round_count] %> rounds</span>
+        <span class="ck-chip ck-chip--<%= @game.difficulty %>"><%= @game.difficulty.capitalize %></span>
+      </div>
+
+      <% if @game.opponent == current_user %>
+        <div class="flex gap-3">
+          <%= button_to "Accept Game", accept_game_path(@game), method: :post, class: "ck-btn-primary flex-1 cursor-pointer" %>
+          <%= button_to "Decline", decline_game_path(@game), method: :post, class: "ck-btn-outline flex-1 cursor-pointer",
+              data: { confirm: "Are you sure you want to decline?" } %>
+        </div>
+      <% else %>
+        <div class="flex items-center gap-2 ck-meta">
+          <svg class="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/>
+          </svg>
+          Waiting for <%= @game.opponent.first_name %> to accept…
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+<% elsif @game.completed? %>
+  <%# ── Completed ─────────────────────────────────────── %>
+  <div class="px-12 py-9">
+    <div class="mb-8">
+      <div class="ck-meta mb-1">Game · Completed</div>
+      <div class="ck-heading">Results</div>
+    </div>
+
+    <div class="ck-card mb-6" style="max-width: 480px; text-align: center;">
+      <% if @game.winner == current_user %>
+        <div class="text-[40px] mb-3">🏆</div>
+        <div class="text-[20px] font-semibold mb-1" style="color: #a6d6ff;">You won!</div>
+        <div class="ck-meta">Great job beating <%= @game.opponent == current_user ? @game.challenger.first_name : @game.opponent.first_name %>.</div>
+      <% else %>
+        <div class="text-[40px] mb-3">😔</div>
+        <div class="text-[20px] font-semibold mb-1"><%= @game.winner.full_name %> won</div>
+        <div class="ck-meta">Better luck next time.</div>
+      <% end %>
+    </div>
+
+    <div class="ck-card" style="max-width: 480px;">
+      <div class="ck-meta mb-4">Round Summary</div>
+      <div class="space-y-3">
+        <% @rounds.each do |round| %>
+          <div class="flex items-center justify-between py-2" style="border-bottom: 0.5px solid var(--ck-line);">
+            <div>
+              <div class="text-[13px] font-medium">Round <%= round.round_number %> · <%= round.challenge.name %></div>
+              <div class="ck-meta"><%= round.challenge.difficulty.capitalize %></div>
+            </div>
+            <% if round.round_winner %>
+              <span class="ck-chip"
+                    style="<%= round.round_winner == current_user ? 'color: #4ade80; background: rgba(74,222,128,0.1);' : '' %>">
+                <%= round.round_winner == current_user ? "You" : round.round_winner.first_name %>
+              </span>
+            <% else %>
+              <span class="ck-chip" style="color: var(--ck-muted);">—</span>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="mt-6">
+      <%= link_to "Back to Home", root_path, class: "ck-btn-outline" %>
+    </div>
+  </div>
+
+<% else %>
+  <%# ── Active game room ──────────────────────────────── %>
+  <div
+    id="game-room"
+    data-controller="game"
+    data-game-game-id-value="<%= @game.id %>"
+    data-game-current-user-id-value="<%= current_user.id %>"
+    data-game-challenge-id-value="<%= @current_round&.challenge&.id %>"
+    data-game-round-id-value="<%= @current_round&.id %>"
+    class="px-12 py-9 space-y-4"
+  >
+    <%# Score banner %>
+    <div id="game-banner" class="hidden ck-card text-center text-[16px] font-semibold"></div>
+
+    <%# Header bar %>
+    <div class="ck-card">
+      <div class="flex items-center justify-between">
+        <div>
+          <div class="ck-meta mb-0.5">Round <span id="current-round-number"><%= @current_round&.round_number || @rounds.size %></span> of <%= Game::ROUND_COUNT_NUM[@game.round_count] %></div>
+          <div class="text-[14px] font-medium" id="current-challenge-name"><%= @current_round&.challenge&.name %></div>
+        </div>
+        <div class="flex gap-6 text-center">
+          <div>
+            <div class="ck-meta mb-0.5">You</div>
+            <div class="text-[18px] font-light tabular-nums" style="color: #a6d6ff;" data-game-target="myScore">
+              <%= @rounds.count { |r| r.round_winner == current_user } %>
+            </div>
+          </div>
+          <div class="ck-meta self-center">—</div>
+          <div>
+            <div class="ck-meta mb-0.5"><%= @game.opponent == current_user ? @game.challenger.first_name : @game.opponent.first_name %></div>
+            <div class="text-[18px] font-light tabular-nums" style="color: var(--ck-muted);" data-game-target="opponentScore">
+              <% opp = @game.opponent == current_user ? @game.challenger : @game.opponent %>
+              <%= @rounds.count { |r| r.round_winner == opp } %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <% if @current_round %>
+      <%# Challenge description %>
+      <details class="ck-card">
+        <summary class="text-[13px] font-semibold cursor-pointer select-none" style="color: var(--ck-ink);">
+          Challenge Description
+        </summary>
+        <div class="mt-3 text-[13px] leading-relaxed whitespace-pre-line" style="color: var(--ck-muted);">
+          <%= @current_round.challenge.description %>
+        </div>
+      </details>
+
+      <%# Code editor %>
+      <div
+        id="code-editor"
+        data-method-template="<%= @current_round.challenge.method_template %>"
+        class="ck-card"
+      >
+        <div class="flex items-center justify-between mb-3">
+          <div class="ck-meta">Ruby</div>
+          <div class="flex gap-2">
+            <% if AppSetting.ai_hints_enabled? %>
+              <button data-action="click->game#hint" class="ck-btn-outline text-[12px] px-3 py-1">
+                💡 Hint
+              </button>
+            <% end %>
+            <button
+              data-action="click->game#run"
+              data-game-target="runBtn"
+              class="ck-btn-primary text-[12px] px-4 py-1"
+            >
+              Run Tests ▶
+            </button>
+          </div>
+        </div>
+
+        <textarea
+          class="hidden"
+          data-game-target="editor"
+        ></textarea>
+
+        <div class="mt-3" style="border-top: 0.5px solid var(--ck-line); padding-top: 12px;">
+          <div class="ck-meta mb-2">Test Results</div>
+          <pre class="text-[12px] font-mono leading-relaxed" style="color: var(--ck-muted);" data-game-target="output">Run your code to see results.</pre>
+        </div>
+      </div>
+    <% else %>
+      <div class="ck-card text-center py-8 ck-meta">All rounds complete.</div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -40,6 +40,28 @@
     </div>
   </div>
 
+  <div class="mb-8">
+    <div class="ck-meta mb-3">Leaderboard</div>
+    <div class="ck-card" style="max-width: 400px;">
+      <% if @leaderboard.any? %>
+        <div class="space-y-3">
+          <% @leaderboard.each_with_index do |player, i| %>
+            <div class="flex items-center gap-3" style="<%= i < @leaderboard.size - 1 ? 'border-bottom: 0.5px solid var(--ck-line); padding-bottom: 10px;' : '' %>">
+              <div class="text-[12px] font-mono w-4 shrink-0" style="color: var(--ck-muted);"><%= i + 1 %></div>
+              <div class="w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-semibold shrink-0" style="background: var(--ck-raised); color: var(--ck-ink);">
+                <%= player.initials %>
+              </div>
+              <%= link_to player.full_name, user_path(player), class: "text-[13px] flex-1 font-medium", style: "color: var(--ck-ink);" %>
+              <div class="text-[13px] font-light tabular-nums" style="color: #a6d6ff;"><%= player.score %></div>
+            </div>
+          <% end %>
+        </div>
+      <% else %>
+        <p class="ck-meta text-[12px]">No scores yet. Play some games!</p>
+      <% end %>
+    </div>
+  </div>
+
   <div>
     <div class="ck-meta mb-3">Friends</div>
     <% if @friends.any? %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -110,6 +110,31 @@
         </div>
       <% end %>
 
+      <div class="ck-card mb-4" style="border-radius: 10px;">
+        <div class="ck-meta mb-3">Game History</div>
+        <% if @game_history.any? %>
+          <div class="space-y-3">
+            <% @game_history.each do |game| %>
+              <% opp = game.challenger == @user ? game.opponent : game.challenger %>
+              <% won = game.winner == @user %>
+              <a href="/games/<%= game.id %>" class="block" style="border-bottom: 0.5px solid var(--ck-line); padding-bottom: 10px; text-decoration: none;">
+                <div class="flex items-center justify-between">
+                  <div>
+                    <div class="text-[12px] font-medium" style="color: var(--ck-ink);">vs <%= opp.full_name %></div>
+                    <div class="ck-meta text-[10px]"><%= Game::ROUND_COUNT_NUM[game.round_count] %> rounds · <%= game.difficulty.capitalize %></div>
+                  </div>
+                  <span class="ck-chip text-[10px]" style="<%= won ? 'color: #4ade80; background: rgba(74,222,128,0.1);' : '' %>">
+                    <%= won ? "W" : "L" %>
+                  </span>
+                </div>
+              </a>
+            <% end %>
+          </div>
+        <% else %>
+          <p class="ck-meta text-[11px]">No games played yet</p>
+        <% end %>
+      </div>
+
       <div class="ck-card" style="border-radius: 10px;">
         <div class="ck-meta mb-3">Friends (<%= @user.friends.count %>)</div>
         <% if @user.friends.any? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,13 +2,9 @@ Rails.application.routes.draw do
   get 'discussions/index'
   resources :posts
   devise_for :users
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
-  # Root redirects to home for authenticated users, sign-in for guests
   authenticated do
     root "home#index"
   end
@@ -16,6 +12,15 @@ Rails.application.routes.draw do
   devise_scope :user do
     unauthenticated do
       root "devise/sessions#new", as: :unauthenticated_root
+    end
+  end
+
+  resources :games, only: %i[new create show] do
+    member do
+      post :accept
+      post :decline
+      post :broadcast_code
+      post :round_won
     end
   end
 
@@ -28,7 +33,7 @@ Rails.application.routes.draw do
   resources :notifications, only: [:index]
   resources :discussions, only: [:index, :show, :new, :create, :edit, :update, :destroy] do
     member do
-      put "upvote", to: "discussions#upvote"
+      put "upvote",   to: "discussions#upvote"
       put "downvote", to: "discussions#downvote"
     end
     resources :posts, only: [:create, :show, :edit, :update, :destroy], module: :discussions
@@ -39,17 +44,16 @@ Rails.application.routes.draw do
   end
 
   resources :categories, only: [:index, :show]
-  resources :users, only: %i[index show], param: :slug
+  resources :users,      only: %i[index show], param: :slug
   resources :challenges, only: %i[index show], param: :name
-  get 'challenges/:room_id/:name', to: 'challenges#room', as: :challenge_room
+  get  'challenges/:room_id/:name', to: 'challenges#room', as: :challenge_room
   post 'evaluate_code', to: 'code_evaluations#evaluate'
+  post 'hints',         to: 'hints#create'
 
   get 'home', to: 'home#index', as: 'home'
 
-  post 'hints', to: 'hints#create'
-
   namespace :admin do
-    get 'settings', to: 'settings#show', as: 'settings'
+    get  'settings', to: 'settings#show',   as: 'settings'
     post 'settings', to: 'settings#update'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,15 +15,6 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :games, only: %i[new create show] do
-    member do
-      post :accept
-      post :decline
-      post :broadcast_code
-      post :round_won
-    end
-  end
-
   resources :invitations, only: [:index, :create] do
     member do
       post :accept
@@ -33,7 +24,7 @@ Rails.application.routes.draw do
   resources :notifications, only: [:index]
   resources :discussions, only: [:index, :show, :new, :create, :edit, :update, :destroy] do
     member do
-      put "upvote",   to: "discussions#upvote"
+      put "upvote", to: "discussions#upvote"
       put "downvote", to: "discussions#downvote"
     end
     resources :posts, only: [:create, :show, :edit, :update, :destroy], module: :discussions
@@ -44,16 +35,26 @@ Rails.application.routes.draw do
   end
 
   resources :categories, only: [:index, :show]
-  resources :users,      only: %i[index show], param: :slug
+  resources :users, only: %i[index show], param: :slug
   resources :challenges, only: %i[index show], param: :name
-  get  'challenges/:room_id/:name', to: 'challenges#room', as: :challenge_room
+  get 'challenges/:room_id/:name', to: 'challenges#room', as: :challenge_room
+  resources :games, only: %i[new create show] do
+    member do
+      post :accept
+      post :decline
+      post :broadcast_code
+      post :round_won
+    end
+  end
+
   post 'evaluate_code', to: 'code_evaluations#evaluate'
-  post 'hints',         to: 'hints#create'
 
   get 'home', to: 'home#index', as: 'home'
 
+  post 'hints', to: 'hints#create'
+
   namespace :admin do
-    get  'settings', to: 'settings#show',   as: 'settings'
+    get 'settings', to: 'settings#show', as: 'settings'
     post 'settings', to: 'settings#update'
   end
 end


### PR DESCRIPTION
## Summary

- **#18 Game creation** — `GamesController` (new/create/show/accept/decline/broadcast_code/round_won), `Game` model additions (`ROUND_COUNT_NUM`, `participant?`), `GameInviteNotification`, `games/new.html.erb` (friend picker, round count, difficulty), games resource routes
- **#19 Accept / decline** — `GameChannel` streams `game_{id}` and rejects non-participants; `games/show.html.erb` pending lobby with accept/decline buttons for opponent, spinner for challenger
- **#20 Live coding** — `game_controller.js` Stimulus controller: CodeMirror editor, debounced code broadcast (400ms), run tests via `/evaluate_code`, automatically signals `round_won` when all tests pass, handles `round_completed` / `game_completed` / `game_started` / `game_declined` broadcasts
- **#21 Result notification** — `GameResultNotification` (STI) created for both players when a game ends; win/loss message links back to the completed game
- **#22 Leaderboard** — `HomeController` loads `@leaderboard` via `User.top_10_by_score`; ranked leaderboard card added to the home dashboard
- **#23 Game history** — `UsersController#show` loads last 10 completed games; game history sidebar card on user profile shows opponent, round count, difficulty, and W/L result

## Test plan

- [ ] Challenge a friend → game invite notification delivered, pending lobby shown
- [ ] Opponent accepts → both players redirected to active game room with CodeMirror
- [ ] Opponent declines → challenger redirected to home
- [ ] Run tests in editor → results displayed; all-pass triggers `round_won` POST
- [ ] Round completes → scores update live via ActionCable; next round loads
- [ ] Final round won → game_completed broadcast, winner/loser result screen shown, scores updated
- [ ] Home dashboard → leaderboard card visible with ranked scores
- [ ] User profile → game history sidebar card shows past games with W/L badges

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhF9kgL2WgNgx8La3BwCC2)_